### PR TITLE
Updating PHP versions

### DIFF
--- a/Runtime_Support/php_support.md
+++ b/Runtime_Support/php_support.md
@@ -34,13 +34,14 @@ The next version of PHP is expected to be [PHP 8.0](https://wiki.php.net/todo/ph
 
 | Version |  Support Status  |  End of Official Support | End of Extended Support | OS Support |
 |---------| ---------------- |:------------------------:|:-----------------------:| ---------- |
-| PHP 5.6 | Extended Support |    December 31, 2018      |    January 01, 2019    | Windows & Linux |
+| PHP 5.6 | End of Life      |    December 31, 2018     |    January 01, 2019    | Windows & Linux |
 | PHP 7.0 | End of Life      |    December 03, 2018     |    February 01, 2020    | Windows & Linux |
 | PHP 7.1 | End of Life      |    December 01, 2019     |    February 01, 2020    | Windows & Linux |
 | PHP 7.2 | End of Life      |    November 30, 2020     |    February 01, 2021    | Windows & Linux |
-| PHP 7.3 | Official Support |    December 06, 2020     |    December 06, 2021    | Windows & Linux |
-| PHP 7.4 | Official Support |    November 28, 2021     |    November 28, 2022    | Windows & Linux |
-| PHP 8.x | Official Support              |    TBD                   |    TBD                  | Linux only |
+| PHP 7.3 | End of Life      |    December 06, 2020     |    December 06, 2021    | Windows & Linux |
+| PHP 7.4 | Extended support |    November 28, 2021     |    November 28, 2022    | Windows & Linux |
+| PHP 8.0 | Official Support |    November 26, 2022     |    November 26, 2023    | Linux only |
+| PHP 8.1 | Official Support |    November 25, 2023     |    November 25, 2024    | TBD |
 
 [PHP Official Support timeline](https://www.php.net/supported-versions.php)
 


### PR DESCRIPTION
I've updated the supported versions of PHP in the table since they were outdated. I haven't seen any communication about supporting PHP 8.1 (released November 25, 2021) so I am not sure if there will be support for PHP 8.1 on the Linux OS.