### PR TITLE
Remove gRPC public preview warning

### DIFF
--- a/HowTo/gRPC/use_gRPC_with_dotnet.md
+++ b/HowTo/gRPC/use_gRPC_with_dotnet.md
@@ -1,8 +1,5 @@
 # How-to deploy a .NET 6 gRPC app on App Service
 
-> [!WARNING]
-> gRPC is currently available to try as a Public Preview feature.
-
 gRPC is a Remote Procedure Call framework that is used to streamline messages between your client and server over HTTP/2.  Using gRPC protocol over HTTP/2 enables the use of features like multiplexing to send multiple parallel requests over the same connection and bi-directional streaming for sending requests and responses simultaneously.  
 
 The following is a tutorial on how to deploy a .NET 6 gRPC application on App Service. 


### PR DESCRIPTION
I believe gRPC is no longer in public preview and is now generally available?