### PR TITLE
Update dot_net_core.md

### DIFF
--- a/Runtime_Support/dot_net_core.md
+++ b/Runtime_Support/dot_net_core.md
@@ -31,7 +31,7 @@ Publishing content to a .NET 5 app works as expected. There is a schedule update
 |---------------| -------------- | ----------------- |---------------- |
 | .NET 6        | LTS            | November 8, 2024    | Windows & Linux |
 | .NET 5        | Current        | May 8, 2022         | Windows & Linux |
-| .NET Core 3.1 | LTS            | December 3, 2022  | Windows & Linux |
+| .NET Core 3.1 | LTS            | December 13, 2022  | Windows & Linux |
 | .NET Core 3.0 | End of Life    | March 3, 2020     | Windows & Linux |
 | .NET Core 2.2 | End of Life    | December 23, 2019 | Windows & Linux |
 | .NET Core 2.1 | End of Life    | August 21, 2021   | Windows & Linux |


### PR DESCRIPTION
	.NET and .NET Core official support policy (microsoft.com) (“Starting with .NET Core 3.1, end of life dates will align with Microsoft Patch Tuesday (second Tuesday of each month). For example, .NET Core 3.1 was originally released on December 3, 2019 and is supported for three years. But the actual end of support day will be the closest Patch Tuesday starting that date, which is December 13, 2022.”)

https://nam06.safelinks.protection.outlook.com/?url=https%3A%2F%2Fdotnet.microsoft.com%2Fen-us%2Fplatform%2Fsupport%2Fpolicy%2Fdotnet-core&data=05%7C01%7Crapopescu%40microsoft.com%7C08136f6336d841a994b508dac19be206%7C72f988bf86f141af91ab2d7cd011db47%7C1%7C0%7C638035173862949793%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000%7C%7C%7C&sdata=ybG%2BGVBn1y1h7lGvjz%2FkHfQpWhx1zkm9XyXe%2B26zL0Q%3D&reserved=0