### PR TITLE
Update ruby_support.md

### DIFF
--- a/Runtime_Support/ruby_support.md
+++ b/Runtime_Support/ruby_support.md
@@ -14,7 +14,7 @@ Existing applications configured to target a runtime version that has reached EO
 
 | Version  | Support Status  |   End of Support  |   OS Support    |
 |----------| --------------- | ----------------- |---------------- |
-| Ruby 2.7 | Current | TBD    | Linux |
+| Ruby 2.7 | Current         | April 12, 2023    | Linux |
 | Ruby 2.6 | security maintenance | March 31, 2022    | Linux |
 | Ruby 2.5 | EOL             | March 31, 2021    | Linux |
 | Ruby 2.4 | EOL             | April 5th, 2020   | Linux |

--- a/Runtime_Support/ruby_support.md
+++ b/Runtime_Support/ruby_support.md
@@ -14,10 +14,10 @@ Existing applications configured to target a runtime version that has reached EO
 
 | Version  | Support Status  |   End of Support  |   OS Support    |
 |----------| --------------- | ----------------- |---------------- |
-| Ruby 2.7 | Current         | April 12, 2023    | Linux |
-| Ruby 2.6 | security maintenance | March 31, 2022    | Linux |
-| Ruby 2.5 | EOL             | March 31, 2021    | Linux |
-| Ruby 2.4 | EOL             | April 5th, 2020   | Linux |
-| Ruby 2.3 | EOL             | March 31, 2019    | Linux |
+| Ruby 2.7 | Current | April 12, 2023 | Linux |
+| Ruby 2.6 | EOL | March 31, 2022  | Linux |
+| Ruby 2.5 | EOL | March 31, 2021  | Linux |
+| Ruby 2.4 | EOL | April 5th, 2020 | Linux |
+| Ruby 2.3 | EOL | March 31, 2019  | Linux |
 
 [Ruby Official Support timeline](https://www.ruby-lang.org/en/downloads/branches/)


### PR DESCRIPTION
Ruby 2.7 support is ending on 12 April 2023.
https://azure.microsoft.com/en-us/updates/rubysupport/