### PR TITLE
Update php_support.md

### DIFF
--- a/Runtime_Support/php_support.md
+++ b/Runtime_Support/php_support.md
@@ -55,6 +55,7 @@ The next version of PHP is expected to be [PHP 8.0](https://wiki.php.net/todo/ph
 | PHP 7.4 | End of Life |    November 28, 2021     |    November 28, 2022    | Windows & Linux |
 | PHP 8.0 | Official Support |    November 22, 2022     |    November 26, 2023    | Linux only |
 | PHP 8.1 | Official Support |    November 25, 2023     |    November 25, 2024    | Linux only |
+| PHP 8.2 | Official Support |    December 08, 2024     |    December 08, 2025    | Linux only |
 
 
 [PHP Official Support timeline](https://www.php.net/supported-versions.php)


### PR DESCRIPTION
PHP 8.2 is available for the App Service, but there is no support expiration date listed in the documentation here.
It seems to be compliant with the support expiration date of the version of PHP itself listed on the following site, so I have created a PR for the change as shown in the commit content. Please check it.

https://www.php.net/supported-versions.php