### PR TITLE
Add bin/www express script and updated env variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,6 @@
 x64/
 x86/
 bld/
-[Bb]in/
 [Oo]bj/
 [Ll]og/
 

--- a/HowTo/gRPC/Node/Node 18 LTS/Server/express-grpc/app.js
+++ b/HowTo/gRPC/Node/Node 18 LTS/Server/express-grpc/app.js
@@ -61,7 +61,7 @@ var packageDefinition = protoLoader.loadSync(
     });
 var hello_proto = grpc.loadPackageDefinition(packageDefinition).helloworld;
 
-var portgRPC = process.env.portHttp2 || 8585
+var portgRPC = process.env.HTTP20_ONLY_PORT || 8585
 
 /**
  * Implements the SayHello RPC method.

--- a/HowTo/gRPC/Node/Node 18 LTS/Server/express-grpc/bin/www
+++ b/HowTo/gRPC/Node/Node 18 LTS/Server/express-grpc/bin/www
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+
+/**
+ * Module dependencies.
+ */
+
+var app = require('../app');
+var debug = require('debug')('express-grpc:server');
+var http = require('http');
+
+/**
+ * Get port from environment and store in Express.
+ */
+
+var port = normalizePort(process.env.PORT || '3000');
+app.set('port', port);
+
+/**
+ * Create HTTP server.
+ */
+
+var server = http.createServer(app);
+
+/**
+ * Listen on provided port, on all network interfaces.
+ */
+
+server.listen(port);
+server.on('error', onError);
+server.on('listening', onListening);
+
+/**
+ * Normalize a port into a number, string, or false.
+ */
+
+function normalizePort(val) {
+  var port = parseInt(val, 10);
+
+  if (isNaN(port)) {
+    // named pipe
+    return val;
+  }
+
+  if (port >= 0) {
+    // port number
+    return port;
+  }
+
+  return false;
+}
+
+/**
+ * Event listener for HTTP server "error" event.
+ */
+
+function onError(error) {
+  if (error.syscall !== 'listen') {
+    throw error;
+  }
+
+  var bind = typeof port === 'string'
+    ? 'Pipe ' + port
+    : 'Port ' + port;
+
+  // handle specific listen errors with friendly messages
+  switch (error.code) {
+    case 'EACCES':
+      console.error(bind + ' requires elevated privileges');
+      process.exit(1);
+      break;
+    case 'EADDRINUSE':
+      console.error(bind + ' is already in use');
+      process.exit(1);
+      break;
+    default:
+      throw error;
+  }
+}
+
+/**
+ * Event listener for HTTP server "listening" event.
+ */
+
+function onListening() {
+  var addr = server.address();
+  var bind = typeof addr === 'string'
+    ? 'pipe ' + addr
+    : 'port ' + addr.port;
+  debug('Listening on ' + bind);
+}


### PR DESCRIPTION
Added the missing `bin/www` express script that is present on the `package.json` `start` script.
If this is used as a sample, running `npm start` after `npm install` will fail without the `bin/www` script.

Updated .gitignore to include the `/bin` folder

It's not possible to re-include a file if a parent directory of that file is excluded ([source](https://git-scm.com/docs/gitignore#_pattern_format)) so I opted to remove the `bin/` folder from the `.gitignore` file.
Future `/bin` outputs can be specifically excluded. None are present at the moment.

Updated the environment variable referencing the HTTP 2.0 Port from `portHttp2` to `HTTP20_ONLY_PORT`, matching the documentation/README.