### PR TITLE
Include the "Turn on end to end encryption" step in Deploy to Linux App Service

### DIFF
--- a/HowTo/gRPC/Linux/.NET/.NET 7/README.md
+++ b/HowTo/gRPC/Linux/.NET/.NET 7/README.md
@@ -50,6 +50,16 @@ App Service requires an application setting that specifically listens for HTTP/2
 
 This setting will communicate to your web app which port is specified to listen over HTTP/2 only.
 
+#### 4. Enable End to End Encryption
+Lastly, App Service requires End to End encryption to be enabled.
+
+Navigate to the [resource explorer](https://resources.azure.com/) and find your application
+Find your application through the following path (click on the + signs):
++ subscriptions > + your-subscription-name > + resourceGroups > + your-resource-group-name > + Providers > + Microsoft.Web > + sites > your-site-name
+Click on Edit
+Find the “endToEndEncryptionEnabled” property and updated the value to true
+Click the PUT button to save the new value
+
 ### Confirm a gRPC request call from your local client
 Now that the gRPC service is deployed and we have a URL, we can make a call from our local client to test that our channel connects to the server and that our client can receive a response.
 


### PR DESCRIPTION
I tried every step before the edit but it didn't work. However, when I checked out the tutorial for Windows, I found this step, tried it and it worked.