### PR TITLE
Update link to Language runtime support policy page

### DIFF
--- a/Runtime_Support/java_support.md
+++ b/Runtime_Support/java_support.md
@@ -1,3 +1,3 @@
 # Java on App Service
 
-For information on our update, support, and runtime retirement policies, please refer to the the official [App Service documentation page for Java](https://learn.microsoft.com/en-us/azure/app-service/language-support-policy?tabs=linux#java-specific-runtime-statement-of-support).
+For information on our update, support, and runtime retirement policies, please refer to the the official [App Service documentation page for Java](https://learn.microsoft.com/azure/app-service/language-support-policy?tabs=linux#java-specific-runtime-statement-of-support).

--- a/Runtime_Support/java_support.md
+++ b/Runtime_Support/java_support.md
@@ -1,3 +1,3 @@
 # Java on App Service
 
-For information on our update, support, and runtime retirement policies, please refer to the the official [App Service documentation page for Java](https://docs.microsoft.com/en-us/azure/app-service/containers/configure-language-java#statement-of-support).
+For information on our update, support, and runtime retirement policies, please refer to the the official [App Service documentation page for Java](https://learn.microsoft.com/en-us/azure/app-service/language-support-policy?tabs=linux#java-specific-runtime-statement-of-support).


### PR DESCRIPTION
When creating a new Web app in Azure Portal, selecting Java 8 as the runtime shows a warning message:

> Java 8 will reach EOL on 3/1/2025 [Learn More](https://go.microsoft.com/fwlink/?linkid=2202628)

The link takes you to this document with another link to the Configure Java Page, but it uses an anchor to a section that does not exist anymore.

This PR updates the link to take users to the Language runtime support policy page, which shows our policies for runtimes for both Linux and Windows.