### PR TITLE
docs: update EOL in python_support.md

### DIFF
--- a/Runtime_Support/python_support.md
+++ b/Runtime_Support/python_support.md
@@ -6,7 +6,7 @@ App Service upgrades the underlying Python runtime of your application as part o
 
 ### End of Life
 
-Once a version of .NET Core has reached it's end of life (EOL) it will no longer be available from Runtime Stack selection dropdown.
+Once a version of Python has reached it's end of life (EOL) it will no longer be available from Runtime Stack selection dropdown.
 
 Existing applications configured to target a runtime version that has reached EOL should not be affected.
 


### PR DESCRIPTION
This pull request includes a small correction to the `Runtime_Support/python_support.md` file. The change updates the text to correctly refer to Python instead of .NET Core in the context of runtime end-of-life information.